### PR TITLE
[WIP] magellan-railsがRabbitMQへの接続や、キューやエクスチェンジにアクセスするための情報を取得できるにする

### DIFF
--- a/Magellan.yml
+++ b/Magellan.yml
@@ -119,6 +119,10 @@ worker1:
   # env:
   #   SECRET_KEY_BASE: "$PROJECT.SECRET_KEY_BASE"
   #   RAILS_ENV: production
+  #   # magellan-railsがタイトル名: vhost, キュー, エクスチェンジの接続時, RabbitMQのユーザ名としてRabbitMQ接続時に使用
+  #   TITLE_NAME: customer1.sample_project
+  #   # magellan-railsがタイトルランタイムバージョン: キュー, エクスチェンジの接続時, ルーティングキーに使用
+  #   TITLE_RUNTIME_VER: 1.0.0
 
   # argument for docker run
   command:


### PR DESCRIPTION
magellan-railsは、[キュー設計](https://docs.google.com/a/groovenauts.jp/spreadsheets/d/1HVIgPHxB4zK0Zc4iLhsk-fSXqPUZKTnPMjQ1TLszdkI/edit#gid=755731678)にあわせてRabbitMQに接続し、
キューやエクスチェンジに対して操作を行うためになんらかの方法で以下の情報を取得する必要があります。
- タイトル名( RabbitMQのユーザ名にも使用します) 
- タイトルランタイムバージョン
- RabbitMQのパスワード
## reviewers
- [ ] @akm  
## Task
- [ ] Magellan.ymlの変更
### 懸念点
- Magellan.ymlに以下のような定義をした場合

```
worker1:
  env:
    TITLE_NAME: customer1.sample_project
```

コンテナ上で動いているmagellan-railsでは、WORKER1_ENV_TITLE_NAME という環境変数でMagellan.ymlのTITLE_NAMEを取得すると思いますが、この際magellan-railsは環境変数TITLE_NAMEの値取得するために、コンテナイメージ名のWORKER1をなんらかの方法で取得する必要があると思われます。
# magellan-railsの引数でコンテナイメージ名が渡せたら嬉しいです
