### PR TITLE
magellan-rails の rails server での development 環境起動時の Subscriber 対応

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'
+require "magellan/rails"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION
magellnan-rails で rails server 起動時に Rails::Application#call から Subscriber 用のリクエストを分岐させたのが利用できるように config/application.rb に require "magellan/rails" を追加しました。
- [x] @akm 
- [x] @kamito 
- [x] @asakaguchi 
