### PR TITLE
リリースされている magellan-rails.gem を利用するように Gemfile を書きかえました。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,18 +40,7 @@ gem 'spring',        group: :development
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
-# インストールする方法で採用したい順位は以下のとおりですが、公開前は1はNGで、
-# dockerを使うとコンテナのイメージをビルドする際のユーザがSSHログインのユーザとは
-# 異なるので2もNGとなってしまいます。ですので仕方なく3の方法を選びます。
-#
-# 1. rubygemsから普通のgemとしてインストール
-# gem "magellan-rails"
-#
-# 2. :git, :branchオプションを使用してインストール
-# gem "magellan-rails", :git => 'git@github.com:tengine/magellan-rails.git', :branch => "features/start_magellan-rails"
-#
-# 3. submoduleで取得した上で :pathオプションを使用してインストール
-gem "magellan-rails" , :path => "gems/magellan-rails"
+gem "magellan-rails"
 
 group :development, :test do
   gem 'rspec-rails', '~> 3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-PATH
-  remote: gems/magellan-rails
-  specs:
-    magellan-rails (0.0.1)
-      bunny
-      json
-      railties (~> 4.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,7 +32,7 @@ GEM
     brocket (0.0.3)
       thor
     builder (3.2.2)
-    bunny (1.4.0)
+    bunny (1.5.0)
       amq-protocol (>= 1.9.2)
     coffee-rails (4.0.1)
       coffee-script (>= 2.2.0)
@@ -62,6 +54,10 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.1)
     libv8 (3.16.14.3)
+    magellan-rails (0.0.1)
+      bunny
+      json
+      railties (~> 4.1.0)
     mail (2.5.4)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
@@ -153,7 +149,7 @@ DEPENDENCIES
   coffee-rails (~> 4.0.0)
   jbuilder (~> 2.0)
   jquery-rails
-  magellan-rails!
+  magellan-rails
   newrelic_rpm
   rails (~> 4.1.0)
   rspec-rails (~> 3.0.0)


### PR DESCRIPTION
開発環境では
`bundler config --local local.magellan-rails (ローカルのmagellan-railsのリポジトリのパス)`
とすることで Gemfile を書き換えずに :path オプションを使ったのと同様に上書きできるはず、だったのですが、どうも bundler 1.7 でうまく動かない(rubygems からインストールされてしまう)ので、magellan-rails の開発の確認の時には書きかえてあげる必要がありそうです。 Bundler/RubyGems の不具合かもしれないので多少 issue を追ってみましたがみつからず。
- [x] @akm 
- [x] @kamito 
