### PR TITLE
magellan上で他のワーカーと同居できるようにしました。

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment',  __FILE__)
-run Rails.application
+map ActionController::Base.config.relative_url_root || "/" do
+  run Rails.application
+end


### PR DESCRIPTION
railsが予め対応している環境変数RAILS_RELATIVE_URL_ROOTを指定することで、相対パスのHTTPリクエストを受け付けることができるようにしました。

http://guides.rubyonrails.org/configuring.html#deploy-to-a-subdirectory-relative-url-root
http://quickhack.net/nom/blog/2012-09-19-rails-with-relative-url-root.html
## 動作確認
### RAILS_RELATIVE_URL_ROOT設定なし

```
$ curl http://localhost:3000/hello/index
{"hello":"world"}
$ curl http://localhost:3000/worker1/hello/index
<!DOCTYPE html>
<html lang="en">
<head>
(snip)
</body>
</html>
```
### RAILS_RELATIVE_URL_ROOT=/worker1

```
$ curl http://localhost:3000/hello/index
Not Found: /hello/index
$ curl http://localhost:3000/worker1/hello/index
{"hello":"world"}
```
## reviewers
- [x] @kamito 
- [x] @nagachika 
- [x] @asakaguchi 
