### PR TITLE
MQTTの認証処理のパターンを追加。

### DIFF
--- a/app/controllers/mqtt_controller.rb
+++ b/app/controllers/mqtt_controller.rb
@@ -5,7 +5,32 @@ class MqttController < ApplicationController
   # MQTTの認証を行なう。
   def auth
     response.headers['X-MQTT-AUTH'] = "YES"
-    render json: {auth: true}
+    auth = {
+      publish_topics:   %w(hello/index worker/pub books/create books/update books/delete_all),
+      subscribe_topics: %w(rooms/001 test/test)
+    }
+    render json: auth.to_json
+  end
+
+  # POST: /mqtt/auth2
+  # MQTTの認証を行なう。
+  # 認証時のボディが空
+  def auth2
+    response.headers['X-MQTT-AUTH'] = "YES"
+    auth = {}
+    render json: auth.to_json
+  end
+
+  # POST: /mqtt/auth3
+  # MQTTの認証を行なう。
+  # 認証時のpub/subトピックが空
+  def auth3
+    response.headers['X-MQTT-AUTH'] = "YES"
+    auth = {
+      publish_topics:   [],
+      subscribe_topics: []
+    }
+    render json: auth.to_json
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,9 @@ Rails.application.routes.draw do
   get 'env'        , to: 'healthcheck#show_env'
   get 'sleep'      , to: 'healthcheck#get_sleep'
 
-  post 'mqtt/auth', to: 'mqtt#auth'
+  post 'mqtt/auth',  to: 'mqtt#auth'
+  post 'mqtt/auth2', to: 'mqtt#auth2'
+  post 'mqtt/auth3', to: 'mqtt#auth3'
 
 
 


### PR DESCRIPTION
## 変更内容

MQTTでの事前認証を行なったときにpub/subのトピック制限を行なうために、
トピック一覧を返して、それを使ってTRのMQTTでpub/subされたときの、
制限チェックを行なう。

## Reviewers

- [x] @akm 
- [x] @nagachika 
- [x] @guemon 
