### PR TITLE
reqsのJSONエンコード時の例外ハンドリングを追加。

### DIFF
--- a/app/controllers/reqs_controller.rb
+++ b/app/controllers/reqs_controller.rb
@@ -39,11 +39,14 @@ class ReqsController < ApplicationController
       {body: body}.to_json
     rescue Encoding::UndefinedConversionError
       body = Base64.strict_encode64(body)
+    rescue JSON::GeneratorError
+      body = Base64.strict_encode64(body)
     end
     dat = {
       method: r.request_method,
       path: r.path_info,
       query: r.query_string,
+      headers: r.headers.each_with_object([]){|(k,v), arr| arr << [k, v] if k =~ /^HTTP_/ },
       body: body,
       params: params
     }


### PR DESCRIPTION
## 変更内容

* reqsのPOSTでバイナリが送信されたときの発生例外が`JSON::GeneratorError `となっていたため、例外補足処理を追加。

## Reviewers

* [x] @guemon 
* [x] @asakaguchi 
* [x] @nagachika 
* [x] @akm 
* [x] @taigou 

